### PR TITLE
Add path.parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -205,6 +205,33 @@ exports.extname = function(path) {
   return splitPath(path)[3];
 };
 
+exports.parse = function(pathString) {
+    assertPath(pathString);
+
+    var allParts = splitPath(pathString);
+    if (!allParts || allParts.length !== 4) {
+        throw new TypeError("Invalid path '" + pathString + "'");
+    }
+    allParts[1] = allParts[1] || '';
+    allParts[2] = allParts[2] || '';
+    allParts[3] = allParts[3] || '';
+
+    return {
+        root: allParts[0],
+        dir: allParts[0] + allParts[1].slice(0, allParts[1].length - 1),
+        base: allParts[2],
+        ext: allParts[3],
+        name: allParts[2].slice(0, allParts[2].length - allParts[3].length)
+    };
+};
+
+function assertPath(path) {
+  if (typeof path !== 'string') {
+    throw new TypeError('Path must be a string. Received ' +
+                        util.inspect(path));
+  }
+}
+
 function filter (xs, f) {
     if (xs.filter) return xs.filter(f);
     var res = [];

--- a/test/test-path.js
+++ b/test/test-path.js
@@ -1,0 +1,22 @@
+var path = require('../index')
+var test = require('tape').test
+
+test('parse works on file', function(t) {
+    var output = path.parse('test-path.js');
+    t.equal(output.root, '', 'root is correct');
+    t.equal(output.dir, '', 'dir is correct');
+    t.equal(output.base, 'test-path.js', 'base is correct');
+    t.equal(output.ext, '.js', 'ext is correct');
+	t.equal(output.name, 'test-path', 'name is correct');
+    t.end();
+})
+
+test('parse works on file with path', function(t) {
+    var output = path.parse('/home/test/test-path.js');
+    t.equal(output.root, '/', 'root is correct');
+    t.equal(output.dir, '/home/test', 'dir is correct');
+    t.equal(output.base, 'test-path.js', 'base is correct');
+    t.equal(output.ext, '.js', 'ext is correct');
+	t.equal(output.name, 'test-path', 'name is correct');
+    t.end();
+})


### PR DESCRIPTION
Path now has a parse function as of v0.12 
This is a cut and paste from here https://github.com/nodejs/node/blob/master/lib/path.js#L592 

As the posix version makes most sense for browserify and browser file system implementations. 

Also added a couple of tape tests to sanity check along with a git ignore for node_modules
